### PR TITLE
change link to pubchem compound-list producer to be correct

### DIFF
--- a/MoleProAPI/java-play-framework-server/conf/dockerTransformers-test.txt
+++ b/MoleProAPI/java-play-framework-server/conf/dockerTransformers-test.txt
@@ -1,5 +1,5 @@
 # compound-list producers
-https://molepro-pubchem-transformer.test.transltr.io/pubchem_producer
+https://molepro-pubchem-transformer.test.transltr.io/pubchem/compounds
 https://molepro-chembl-transformer.test.transltr.io/chembl/molecules
 https://molepro-drugbank-transformer.test.transltr.io/drugbank/compounds
 https://molepro-chembank-transformer.test.transltr.io/chembank/compounds


### PR DESCRIPTION
Change the tail end of the hyperlink to the Test pubchem producer.