### PR TITLE
change link to pubchem compound-list producer to be correct

### DIFF
--- a/MoleProAPI/java-play-framework-server/conf/dockerTransformers-prod.txt
+++ b/MoleProAPI/java-play-framework-server/conf/dockerTransformers-prod.txt
@@ -1,5 +1,5 @@
 # compound-list producers
-https://molepro-pubchem-transformer.transltr.io/pubchem_producer
+https://molepro-pubchem-transformer.transltr.io/pubchem/compounds
 https://molepro-chembl-transformer.transltr.io/chembl/molecules
 https://molepro-drugbank-transformer.transltr.io/drugbank/compounds
 https://molepro-chembank-transformer.transltr.io/chembank/compounds


### PR DESCRIPTION
Make a correction to the tail end of the hyperlink to Pubchem compound list producer in Prod.