### PR TITLE
Bump numpy from 1.17.3 to 1.22.0 in /transformers/msigdb/python-flask-server

### DIFF
--- a/transformers/msigdb/python-flask-server/requirements.txt
+++ b/transformers/msigdb/python-flask-server/requirements.txt
@@ -6,5 +6,5 @@ python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 werkzeug == 2.0.3; python_version>="3.6"
 gunicorn >= 20.1.0
-numpy == 1.17.3
+numpy == 1.22.0
 scipy == 1.3


### PR DESCRIPTION

Bump numpy in /transformers/msigdb/python-flask-server Bumps [numpy](https://github.com/numpy/numpy) from 1.17.3 to 1.22.0.
- [Release notes](https://github.com/numpy/numpy/releases)
- [Changelog](https://github.com/numpy/numpy/blob/main/doc/RELEASE_WALKTHROUGH.rst)
- [Commits](numpy/numpy@v1.17.3...v1.22.0)

---
updated-dependencies:
- dependency-name: numpy dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>